### PR TITLE
add synctime command (set node time from local time)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,27 @@ SET(FILES ${CMAKE_SOURCE_DIR}/connection.cpp
 		  ${CMAKE_SOURCE_DIR}/quottery.cpp
 		  ${CMAKE_SOURCE_DIR}/qutil.cpp
 )
-ADD_EXECUTABLE(qubic-cli main.cpp ${FILES})
+SET(HEADER_FILES
+	K12AndKeyUtil.h
+	SCUtils.h
+	argparser.h
+	assetUtil.h
+	connection.h
+	defines.h
+	fourq-qubic.h
+	global.h
+	keyUtils.h
+	logger.h
+	nodeUtils.h
+	prompt.h
+	qubicLogParser.h
+	quottery.h
+	qutil.h
+	sanityCheck.h
+	structs.h
+	utils.h
+	walletUtils.h
+)
+ADD_EXECUTABLE(qubic-cli main.cpp ${FILES} ${HEADER_FILES})
 ADD_LIBRARY(fourq-qubic fourq-qubic.cpp)
 target_compile_options(fourq-qubic PRIVATE -DBUILD_4Q_LIB)

--- a/argparser.h
+++ b/argparser.h
@@ -81,6 +81,8 @@ void print_help(){
     printf("\t\tSend a raw packet to nodeip. Valid node ip/port are required.\n");
     printf("\t-getlogfromnode <PASSCODE_0> <PASSCODE_1> <PASSCODE_2> <PASSCODE_3>\n");
     printf("\t\tFetch a single log line from the node. Valid node ip/port, passcodes are required.\n");
+    printf("\t-synctime\n");
+    printf("\t\tSync node time with local time, valid private key and node ip/port are required. Make sure that your local time is synced (with NTP)!\t\n");
 
     printf("\n[QX COMMAND]\n");
     printf("\t-qxgetfee\n");
@@ -431,6 +433,14 @@ void parseArgument(int argc, char** argv){
             g_cmd = REISSUE_VOTE;
             g_requestedSpecialCommand = SPECIAL_COMMAND_REISSUE_VOTE;
             i+=1;
+            CHECK_OVER_PARAMETERS
+            break;
+        }
+        if (strcmp(argv[i], "-synctime") == 0)
+        {
+            g_cmd = SYNC_TIME;
+            g_requestedSpecialCommand = SPECIAL_COMMAND_SEND_TIME;
+            i += 1;
             CHECK_OVER_PARAMETERS
             break;
         }

--- a/connection.cpp
+++ b/connection.cpp
@@ -142,3 +142,4 @@ int QubicConnection::sendData(uint8_t* buffer, int sz)
 template SpecialCommand QubicConnection::receivePacketAs<SpecialCommand>();
 template SpecialCommandToggleMainModeResquestAndResponse QubicConnection::receivePacketAs<SpecialCommandToggleMainModeResquestAndResponse>();
 template SpecialCommandSetSolutionThresholdResquestAndResponse QubicConnection::receivePacketAs<SpecialCommandSetSolutionThresholdResquestAndResponse>();
+template SpecialCommandSendTime QubicConnection::receivePacketAs<SpecialCommandSendTime>();

--- a/defines.h
+++ b/defines.h
@@ -34,6 +34,8 @@
 #define SPECIAL_COMMAND_REFRESH_PEER_LIST 9ULL // F4
 #define SPECIAL_COMMAND_FORCE_NEXT_TICK 10ULL // F5
 #define SPECIAL_COMMAND_REISSUE_VOTE 11ULL // F9
+#define SPECIAL_COMMAND_QUERY_TIME 12ULL    // send this to node to query time, responds with time read from clock
+#define SPECIAL_COMMAND_SEND_TIME 13ULL     // send this to node to set time, responds with time read from clock after setting
 
 #define QX_CONTRACT_INDEX 1
 #define QX_FEE_FUNCTION_INDEX 1

--- a/main.cpp
+++ b/main.cpp
@@ -212,6 +212,11 @@ int main(int argc, char *argv[])
             sanityCheckSpecialCommand(g_requestedSpecialCommand);
             sendSpecialCommand(g_nodeIp, g_nodePort, g_seed, g_requestedSpecialCommand);
             break;
+        case SYNC_TIME:
+            sanityCheckNode(g_nodeIp, g_nodePort);
+            sanityCheckSeed(g_seed);
+            syncTime(g_nodeIp, g_nodePort, g_seed);
+            break;
         case QUTIL_SEND_TO_MANY_V1:
             sanityCheckNode(g_nodeIp, g_nodePort);
             sanityCheckSeed(g_seed);

--- a/nodeUtils.cpp
+++ b/nodeUtils.cpp
@@ -426,7 +426,7 @@ void sendSpecialCommand(const char* nodeIp, const int nodePort, const char* seed
     if (response.everIncreasingNonceAndCommandType == packet.cmd.everIncreasingNonceAndCommandType){
         LOG("Node received special command\n");
     } else{
-        if (command != REFRESH_PEER_LIST){
+        if (command != SPECIAL_COMMAND_REFRESH_PEER_LIST){
             LOG("Failed to send special command\n");
         } else {
             LOG("Sent special command\n"); // the connection is refreshed right after this command, no way to verify remotely

--- a/nodeUtils.cpp
+++ b/nodeUtils.cpp
@@ -614,7 +614,7 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         auto endTime = std::chrono::steady_clock::now();
         auto nowLocal = std::chrono::system_clock::now();
         delete qc;
-        if (response.everIncreasingNonceAndCommandType != queryTimeMsg.cmd.everIncreasingNonceAndCommandType) {
+        if ((response.everIncreasingNonceAndCommandType & 0xFFFFFFFFFFFFFF) != (queryTimeMsg.cmd.everIncreasingNonceAndCommandType & 0xFFFFFFFFFFFFFF)) {
             LOG("Failed to query node time!\n");
             return;
         }

--- a/nodeUtils.cpp
+++ b/nodeUtils.cpp
@@ -536,7 +536,7 @@ void logTime(const UtcTime& time)
     LOG("%u-%02u-%02u %02u:%02u:%02u.%09u", time.year, time.month, time.day, time.hour, time.minute, time.second, time.nanosecond);
 }
 
-UtcTime convertTime(std::chrono::system_clock::time_point & time)
+UtcTime convertTime(std::chrono::system_clock::time_point time)
 {
     using namespace std;
     using namespace std::chrono;

--- a/nodeUtils.cpp
+++ b/nodeUtils.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <algorithm>
+#include <chrono>
 #include "structs.h"
 #include "connection.h"
 #include "nodeUtils.h"
@@ -527,6 +528,153 @@ void setSolutionThreshold(const char* nodeIp, const int nodePort, const char* se
         }
     } else{
         LOG("Failed set solution threshold\n");
+    }
+}
+
+void logTime(const UtcTime& time)
+{
+    LOG("%u-%02u-%02u %02u:%02u:%02u.%09u", time.year, time.month, time.day, time.hour, time.minute, time.second, time.nanosecond);
+}
+
+UtcTime convertTime(std::chrono::system_clock::time_point & time)
+{
+    using namespace std;
+    using namespace std::chrono;
+
+    time_t tt = system_clock::to_time_t(time);
+    tm utc_tm = *gmtime(&tt);
+    UtcTime utcTime;
+    utcTime.year = utc_tm.tm_year + 1900;
+    utcTime.month = utc_tm.tm_mon + 1;
+    utcTime.day = utc_tm.tm_mday;
+    utcTime.hour = utc_tm.tm_hour;
+    utcTime.minute = utc_tm.tm_min;
+    utcTime.second = utc_tm.tm_sec;
+
+    // get nanoseconds
+    typedef duration<int, ratio_multiply<hours::period, ratio<24> >::type> days;
+    system_clock::duration tp = time.time_since_epoch();
+    days d = duration_cast<days>(tp);
+    tp -= d;
+    hours h = duration_cast<hours>(tp);
+    tp -= h;
+    minutes m = duration_cast<minutes>(tp);
+    tp -= m;
+    seconds s = duration_cast<seconds>(tp);
+    tp -= s;
+    utcTime.nanosecond = duration_cast<nanoseconds>(tp).count();
+
+    return utcTime;
+}
+
+void syncTime(const char* nodeIp, const int nodePort, const char* seed)
+{
+    uint8_t privateKey[32] = { 0 };
+    uint8_t sourcePublicKey[32] = { 0 };
+    uint8_t subseed[32] = { 0 };
+    uint8_t digest[32] = { 0 };
+    uint8_t signature[64] = { 0 };
+    getSubseedFromSeed((uint8_t*)seed, subseed);
+    getPrivateKeyFromSubSeed(subseed, privateKey);
+    getPublicKeyFromPrivateKey(privateKey, sourcePublicKey);
+
+    LOG("---------------------------------------------------------------------------------\n");
+    LOG("This sets the node clock to roughly be in sync with the local clock.\n");
+    LOG("CAUTION: MAKE SURE THAT YOUR LOCAL CLOCK IS SET CORRECTLY, FOR EXAMPLE USING NTP.\n");
+    LOG("---------------------------------------------------------------------------------\n\n");
+
+    // get time from node and measure round trip time
+    unsigned long long roundTripTimeNanosec = 0;
+    {
+        LOG("Querying node time ...\n\n");
+
+        struct {
+            RequestResponseHeader header;
+            SpecialCommand cmd;
+            uint8_t signature[64];
+        } queryTimeMsg;
+        queryTimeMsg.header.setSize(sizeof(queryTimeMsg));
+        queryTimeMsg.header.randomizeDejavu();
+        queryTimeMsg.header.setType(PROCESS_SPECIAL_COMMAND);
+        uint64_t curTime = time(NULL);
+        uint64_t commandByte = (uint64_t)(SPECIAL_COMMAND_QUERY_TIME) << 56;
+        queryTimeMsg.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
+
+        KangarooTwelve((unsigned char*)&queryTimeMsg.cmd,
+            sizeof(queryTimeMsg.cmd),
+            digest,
+            32);
+        sign(subseed, sourcePublicKey, digest, signature);
+        memcpy(queryTimeMsg.signature, signature, 64);
+
+        auto qc = new QubicConnection(nodeIp, nodePort);
+        auto startTime = std::chrono::steady_clock::now();
+        qc->sendData((uint8_t*)&queryTimeMsg, queryTimeMsg.header.size());
+        auto response = qc->receivePacketAs<SpecialCommandSendTime>();
+        auto endTime = std::chrono::steady_clock::now();
+        auto nowLocal = std::chrono::system_clock::now();
+        delete qc;
+        if (response.everIncreasingNonceAndCommandType != queryTimeMsg.cmd.everIncreasingNonceAndCommandType) {
+            LOG("Failed to query node time!\n");
+            return;
+        }
+
+        roundTripTimeNanosec = std::chrono::duration<unsigned long long, std::nano>(endTime - startTime).count();
+        LOG("Clock status before sync:\n");
+        LOG("\tNode time (UTC):  "); logTime(response.utcTime); LOG("  -  round trip time %llu ms\n", roundTripTimeNanosec / 1000000);
+        LOG("\tLocal time (UTC): "); logTime(convertTime(nowLocal)); LOG("\n\n");
+    }
+
+    if (roundTripTimeNanosec > 3000000000llu)
+    {
+        LOG("Round trip time is too large. Sync skipped, because it would be very inaccurate!");
+        return;
+    }
+
+    // set node clock to local UTC time + half round trip time (not very accurate but simple and sufficient for requirements of 5 seconds)
+    {
+        struct {
+            RequestResponseHeader header;
+            SpecialCommandSendTime cmd;
+            uint8_t signature[64];
+        } sendTimeMsg;
+        sendTimeMsg.header.setSize(sizeof(sendTimeMsg));
+        sendTimeMsg.header.randomizeDejavu();
+        sendTimeMsg.header.setType(PROCESS_SPECIAL_COMMAND);
+        uint64_t curTime = time(NULL);
+        uint64_t commandByte = (uint64_t)(SPECIAL_COMMAND_SEND_TIME) << 56;
+        sendTimeMsg.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
+
+        using namespace std::chrono;
+        auto now = system_clock::now();
+        auto halfRoudTripTime = duration_cast<system_clock::duration>(nanoseconds(roundTripTimeNanosec / 2));
+        UtcTime timeToSet = convertTime(now + halfRoudTripTime);
+        sendTimeMsg.cmd.utcTime = timeToSet;
+        LOG("Setting node time to "); logTime(timeToSet); LOG(" ...\n\n");
+
+        KangarooTwelve((unsigned char*)&sendTimeMsg.cmd,
+            sizeof(sendTimeMsg.cmd),
+            digest,
+            32);
+        sign(subseed, sourcePublicKey, digest, signature);
+        memcpy(sendTimeMsg.signature, signature, 64);
+
+        auto qc = new QubicConnection(nodeIp, nodePort);
+        auto startTime = std::chrono::steady_clock::now();
+        qc->sendData((uint8_t*)&sendTimeMsg, sendTimeMsg.header.size());
+        auto response = qc->receivePacketAs<SpecialCommandSendTime>();
+        auto endTime = std::chrono::steady_clock::now();
+        auto nowLocal = std::chrono::system_clock::now();
+        delete qc;
+        if (response.everIncreasingNonceAndCommandType != sendTimeMsg.cmd.everIncreasingNonceAndCommandType) {
+            LOG("Failed to set node time!\n");
+            return;
+        }
+
+        roundTripTimeNanosec = std::chrono::duration<unsigned long long, std::nano>(endTime - startTime).count();
+        LOG("Clock status after sync:\n");
+        LOG("\tNode time (UTC):  "); logTime(response.utcTime); LOG("  -  round trip time %llu ms\n", roundTripTimeNanosec / 1000000);
+        LOG("\tLocal time (UTC): "); logTime(convertTime(nowLocal)); LOG("\n\n");
     }
 }
 

--- a/nodeUtils.h
+++ b/nodeUtils.h
@@ -18,3 +18,4 @@ void toogleMainAux(const char* nodeIp, const int nodePort, const char* seed,
                    int command, std::string mode0, std::string mode1);
 void setSolutionThreshold(const char* nodeIp, const int nodePort, const char* seed,
                           int command, int epoch, int threshold);
+void syncTime(const char* nodeIp, const int nodePort, const char* seed);

--- a/structs.h
+++ b/structs.h
@@ -44,7 +44,8 @@ enum COMMAND
     FORCE_NEXT_TICK=37,
     REISSUE_VOTE=38,
     QUTIL_SEND_TO_MANY_V1=39,
-    TOTAL_COMMAND = 40
+    TOTAL_COMMAND = 40,
+    SYNC_TIME = 41,
 };
 
 struct RequestResponseHeader {
@@ -406,6 +407,28 @@ struct SpecialCommandSetSolutionThresholdResquestAndResponse
     unsigned long long everIncreasingNonceAndCommandType;
     unsigned int epoch;
     int threshold;
+    static constexpr unsigned char type()
+    {
+        return 255;
+    }
+};
+
+struct UtcTime
+{
+    unsigned short    year;              // 1900 - 9999
+    unsigned char     month;             // 1 - 12
+    unsigned char     day;               // 1 - 31
+    unsigned char     hour;              // 0 - 23
+    unsigned char     minute;            // 0 - 59
+    unsigned char     second;            // 0 - 59
+    unsigned char     pad1;
+    unsigned int      nanosecond;        // 0 - 999,999,999
+};
+
+struct SpecialCommandSendTime
+{
+    unsigned long long everIncreasingNonceAndCommandType;
+    UtcTime utcTime;
     static constexpr unsigned char type()
     {
         return 255;


### PR DESCRIPTION
This adds a command to sync the time of the node with the local time.

It implements the feature request https://github.com/qubic/core/issues/44

This PR should be tested together with the corresponding PR in the core repository https://github.com/qubic/core/pull/53.