### PR TITLE
Remove possessor argument from qx transfer asset message

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Command:
         Show current Qx fee.
     -qxissueasset <ASSET_NAME> <NUMBER_OF_UNIT> <UNIT_OF_MEASUREMENT> <NUM_DECIMAL>
         Create an asset via Qx contract.
-    -qxtransferasset <ASSET_NAME> <ISSUER_IN_HEX> <POSSESSED_IDENTITY> <NEW_OWNER_IDENTITY> <AMOUNT_OF_SHARE>
+    -qxtransferasset <ASSET_NAME> <ISSUER_IN_HEX> <NEW_OWNER_IDENTITY> <AMOUNT_OF_SHARE>
         Transfer an asset via Qx contract.
 
 [QTRY COMMAND]

--- a/argparser.h
+++ b/argparser.h
@@ -93,7 +93,7 @@ void print_help(){
     printf("\t\tShow current Qx fee.\n");
     printf("\t-qxissueasset <ASSET_NAME> <NUMBER_OF_UNIT> <UNIT_OF_MEASUREMENT> <NUM_DECIMAL>\n");
     printf("\t\tCreate an asset via Qx contract.\n");
-    printf("\t-qxtransferasset <ASSET_NAME> <ISSUER_IN_HEX> <POSSESSED_IDENTITY> <NEW_OWNER_IDENTITY> <AMOUNT_OF_SHARE>\n");
+    printf("\t-qxtransferasset <ASSET_NAME> <ISSUER_IN_HEX> <NEW_OWNER_IDENTITY> <AMOUNT_OF_SHARE>\n");
     printf("\t\tTransfer an asset via Qx contract.\n");
 
     printf("\n[QTRY COMMAND]\n");
@@ -514,10 +514,9 @@ void parseArgument(int argc, char** argv){
             g_cmd = QX_TRANSFER_ASSET;
             g_qx_asset_transfer_asset_name = argv[i+1];
             g_qx_asset_transfer_issuer_in_hex = argv[i+2];
-            g_qx_asset_transfer_possessed_identity = argv[i+3];
-            g_qx_asset_transfer_new_owner_identity = argv[i+4];
-            g_qx_asset_transfer_amount = charToNumber(argv[i+5]);
-            i+=6;
+            g_qx_asset_transfer_new_owner_identity = argv[i+3];
+            g_qx_asset_transfer_amount = charToNumber(argv[i+4]);
+            i+=5;
             CHECK_OVER_PARAMETERS
             break;
         }

--- a/assetUtil.h
+++ b/assetUtil.h
@@ -20,7 +20,6 @@ void qxTransferAsset(const char* nodeIp, int nodePort,
                      const char* seed,
                      const char* pAssetName,
                      const char* pIssuer,
-                     const char* possessorIdentity,
                      const char* newOwnerIdentity,
                      long long numberOfUnits,
                      uint32_t scheduledTickOffset);

--- a/assetUtils.cpp
+++ b/assetUtils.cpp
@@ -198,7 +198,6 @@ void qxTransferAsset(const char* nodeIp, int nodePort,
                      const char* seed,
                      const char* pAssetName,
                      const char* pIssuer,
-                     const char* possessorIdentity,
                      const char* newOwnerIdentity,
                      long long numberOfUnits,
                      uint32_t scheduledTickOffset)
@@ -211,7 +210,6 @@ void qxTransferAsset(const char* nodeIp, int nodePort,
     uint8_t digest[32] = {0};
     uint8_t signature[64] = {0};
     uint8_t issuer[32] = {0};
-    uint8_t possessorPublicKey[32] = {0};
     uint8_t newOwnerPublicKey[32] = {0};
     char txHash[128] = {0};
     char assetNameU1[8] = {0};
@@ -223,7 +221,6 @@ void qxTransferAsset(const char* nodeIp, int nodePort,
     getPrivateKeyFromSubSeed(subSeed, privateKey);
     getPublicKeyFromPrivateKey(privateKey, sourcePublicKey);
     getPublicKeyFromIdentity(QX_ADDRESS, destPublicKey);
-    getPublicKeyFromIdentity(possessorIdentity, possessorPublicKey);
     getPublicKeyFromIdentity(newOwnerIdentity, newOwnerPublicKey);
     struct {
         RequestResponseHeader header;
@@ -248,8 +245,7 @@ void qxTransferAsset(const char* nodeIp, int nodePort,
     // fill the input
     memcpy(&packet.ta.assetName, assetNameU1, 8);
     memcpy(packet.ta.issuer, issuer, 32);
-    memcpy(packet.ta.possessor, possessorPublicKey, 32);
-    memcpy(packet.ta.newOwner, newOwnerPublicKey, 32);
+    memcpy(packet.ta.newOwnerAndPossessor, newOwnerPublicKey, 32);
     packet.ta.numberOfUnits = numberOfUnits;
     // sign the packet
     KangarooTwelve((unsigned char*)&packet.transaction,

--- a/main.cpp
+++ b/main.cpp
@@ -111,15 +111,13 @@ int main(int argc, char *argv[])
             sanityCheckNumberOfUnit(g_qx_asset_transfer_amount);
             sanityCheckValidString(g_qx_asset_transfer_asset_name);
             sanityCheckValidString(g_qx_asset_transfer_issuer_in_hex);
-            sanityCheckIdentity(g_qx_asset_transfer_possessed_identity);
             sanityCheckIdentity(g_qx_asset_transfer_new_owner_identity);
             qxTransferAsset(g_nodeIp, g_nodePort, g_seed,
                             g_qx_asset_transfer_asset_name,
                             g_qx_asset_transfer_issuer_in_hex,
-                            g_qx_asset_transfer_possessed_identity,
                             g_qx_asset_transfer_new_owner_identity,
                             g_qx_asset_transfer_amount,
-                         g_offsetScheduledTick);
+                            g_offsetScheduledTick);
             break;
         case GET_COMP_LIST:
             sanityCheckNode(g_nodeIp, g_nodePort);

--- a/structs.h
+++ b/structs.h
@@ -359,8 +359,7 @@ typedef struct
 typedef struct
 {
     uint8_t issuer[32];
-    uint8_t possessor[32];
-    uint8_t newOwner[32];
+    uint8_t newOwnerAndPossessor[32];
     unsigned long long assetName;
     long long numberOfUnits;
 } TransferAssetOwnershipAndPossession_input;


### PR DESCRIPTION
See: https://github.com/orgs/qubic/projects/1/views/1?pane=issue&itemId=56387873

copied from issue:

change qx share transfer invocation
please change qx transfer share invocation in qubic-cli according to: https://github.com/qubic/core/commit/3f775cf640f90c06408e2e73a602b10eda9254d4

@J0ET0M as discussed. Please check.
