### PR TITLE
Added little guide to how to fix this error during build in linux : No CMAKE_CXX_COMPILER could be found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ Check tx on online:
 
 `./qubic-cli -nodeip 127.0.0.1 -checktxontick 10600000 TX_HASH`
 
+### Possible exceptions encountered during build on Linux
+When building the project, you may encounter the following exception under Linux: 
+
+`$ No CMAKE_CXX_COMPILER could be found.`
+
+This exception can be resolved by installing the following package `build-essential`:
+
+`sudo apt-get install build-essential`
+
+---
+
 More information, please read the help. `./qubic-cli -help`
 
 #### NOTE: PROPER ACTIONS are needed if you use this tool as a replacement for qubic wallet. Please use it with caution.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ When building the project, you may encounter the following exception under Linux
 
 `$ No CMAKE_CXX_COMPILER could be found.`
 
-This exception can be resolved by installing the following package `build-essential`:
+This error can be resolved by installing the following package `build-essential`:
 
 `sudo apt-get install build-essential`
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Check tx on online:
 
 `./qubic-cli -nodeip 127.0.0.1 -checktxontick 10600000 TX_HASH`
 
-### Possible exceptions encountered during build on Linux
+### Possible errors encountered during build on Linux
 When building the project, you may encounter the following exception under Linux: 
 
 `$ No CMAKE_CXX_COMPILER could be found.`


### PR DESCRIPTION
When building the project under Linux, some users may get the following error: 

- No CMAKE_CXX_COMPILER could be found

I've updated the README file, adding the package ( _build-essential_ ) to be installed as well, in order to resolve this error.