### PR TITLE
Allow getbalance option will also calculate the spectrum digest.

### DIFF
--- a/keyUtils.cpp
+++ b/keyUtils.cpp
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <vector>
 #include "keyUtils.h"
 #include "K12AndKeyUtil.h"
 #include "logger.h"
@@ -108,3 +109,55 @@ bool checkSumIdentity(char* identity)
     }
     return true;
 }
+
+template <unsigned int hashByteLen>
+void getDigestFromSiblings(
+    unsigned int depth,
+    const uint8_t *input,
+    unsigned int inputByteLen,
+    unsigned int inputIndex,
+    const uint8_t (*siblings)[hashByteLen],
+    uint8_t *output)
+    {
+    const uint32_t hash_byte_lenx2 = (hashByteLen << 1);
+    std::vector<uint8_t> pair_digests(hash_byte_lenx2);
+    std::vector<uint8_t> digest(hashByteLen);
+
+    // Hash the input
+    KangarooTwelve(input, inputByteLen, digest.data(), hashByteLen);
+
+    // Loop through the siblings hash and go to the root
+    unsigned int digest_index = inputIndex;
+    for (unsigned int i = 0 ; i < depth; i++)
+    {
+        uint8_t const* fisrt_digest = digest.data();
+        uint8_t const* second_digest = siblings[i];
+        // Depend on the odd or even of the index, the sibling is left or right node of the tree
+        // odd - sibling is the left node
+        // even - sibling is the right node
+        if (digest_index % 2 == 1)
+        {
+            fisrt_digest = siblings[i];
+            second_digest = digest.data();
+        }
+        // Concatenate pair of hashes
+        memcpy(pair_digests.data(), fisrt_digest, hashByteLen);
+        memcpy(pair_digests.data() + hashByteLen, second_digest, hashByteLen);
+
+        // Calculate the new hash for next level
+        KangarooTwelve(pair_digests.data(), hash_byte_lenx2, digest.data(), hashByteLen);
+
+        // Index of next level
+        digest_index = (digest_index >> 1);
+    }
+    memcpy(output, digest.data(), hashByteLen);
+}
+
+template
+void getDigestFromSiblings<32>(
+    unsigned int depth,
+    const uint8_t *input,
+    unsigned int inputByteLen,
+    unsigned int inputIndex,
+    const uint8_t (*siblings)[32],
+    uint8_t *output);

--- a/keyUtils.h
+++ b/keyUtils.h
@@ -6,3 +6,13 @@ void getIdentityFromPublicKey(const uint8_t* pubkey, char* identity, bool isLowe
 void getTxHashFromDigest(const uint8_t* digest, char* txHash);
 void getPublicKeyFromIdentity(const char* identity, uint8_t* publicKey);
 bool checkSumIdentity(char* identity);
+
+// Compute the digest (root hash) from siblings of Merkle tree
+template <unsigned int hashByteLen>
+void getDigestFromSiblings(
+    unsigned int depth,
+    const uint8_t *input,
+    unsigned int inputByteLen,
+    unsigned int inputIndex,
+    const uint8_t (*siblings)[hashByteLen],
+    uint8_t *output);


### PR DESCRIPTION
This PR allow getbalance option calculate the spectrum digest.
Below is the example output
```
./qubic-cli -nodeip <IP> -getbalance FSNAVIFGVIHLRAHOASPVAJKFYLCDMPWQJUCVQPHOGEVJJACUQKBABEUBEAGE
Identity: FSNAVIFGVIHLRAHOASPVAJKFYLCDMPWQJUCVQPHOGEVJJACUQKBABEUBEAGE
Balance: 1464960931
Incoming Amount: 3387595483
Outgoing Amount: 1922634552
Number Of Incoming Transfers: 10
Number Of Outgoing Transfers: 6016
Latest Incoming Transfer Tick: 13773994
Latest Outgoing Transfer Tick: 13771627
Tick: 13821215
Spectum Digest: 148a8da88469bd7ca9ccdfb68ccee35500a6c66b4e20bfee52705bd231dbcc03


===============================================================================
./qubic-cli -seed  -nodeip <IP> -getquorumtick ./computorlist.txt 13821215
Received 564 quorum tick #13821215 (votes)
Received 562 quorum tick #13821216 (votes)
Performing salt check...
ALL votes PASSED salts check
Number of unique votes: 1
Vote #0 (voted by 564 computors ID) Epoch: 108
Tick: 13821215
Time: 2024-05-08 14:10:49.0000
prevResourceTestingDigest: 33fcf81b2275e644
prevSpectrumDigest: 148a8da88469bd7ca9ccdfb68ccee35500a6c66b4e20bfee52705bd231dbcc03
prevUniverseDigest: 46285cb31737544ed56c9b8ac9500bfec425e642d7e276a571f73088fb6a458c
prevComputerDigest: eddfe392253efd3f58da9d2ba04c5bde389193bc14b75048205ae3c1ef95a113
transactionDigest: 99b0e37560172e478289d7a37e6ed240b419d792dd0d48019388f341fb3922ef
expectedNextTickTransactionDigest: 81d0c66a1b01910ca1d246f5bd9097aba2502cf7afd7878d3410a726bd24da42
```