### PR TITLE
Add ability to send transaction in specific tick

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Command:
                 Print a list of assets of an identity
         -sendtoaddress <TARGET_IDENTITY> <AMOUNT>
                 Perform a standard transaction to sendData <AMOUNT> qubic to <TARGET_IDENTITY>. valid private key and node ip/port are required.
+        -sendtoaddressintick <TARGET_IDENTITY> <AMOUNT> <TICK>
+                Perform a standard transaction to sendData <AMOUNT> qubic to <TARGET_IDENTITY> in a specific <TICK>. A valid private key and node ip/port are required.
 
 [BLOCKCHAIN/PROTOCOL COMMAND]
         -gettickdata <TICK_NUMBER> <OUTPUT_FILE_NAME>

--- a/argparser.h
+++ b/argparser.h
@@ -34,7 +34,9 @@ void print_help(){
     printf("\t-getasset <IDENTITY>\n");
     printf("\t\tPrint a list of assets of an identity\n");
     printf("\t-sendtoaddress <TARGET_IDENTITY> <AMOUNT>\n");
-    printf("\t\tPerform a standard transaction to sendData <AMOUNT> qubic to <TARGET_IDENTITY>. valid private key and node ip/port are required.\n");
+    printf("\t\tPerform a standard transaction to sendData <AMOUNT> qubic to <TARGET_IDENTITY>. A valid private key and node ip/port are required.\n");
+    printf("\t-sendtoaddressintick <TARGET_IDENTITY> <AMOUNT> <TICK>\n");
+    printf("\t\tPerform a standard transaction to sendData <AMOUNT> qubic to <TARGET_IDENTITY> in a specific <TICK>. A valid private key and node ip/port are required.\n");
     printf("\n[BLOCKCHAIN/PROTOCOL COMMAND]\n");
     printf("\t-gettickdata <TICK_NUMBER> <OUTPUT_FILE_NAME>\n");
     printf("\t\tGet tick data and write it to a file. Use -readtickdata to examine the file. valid node ip/port are required.\n");
@@ -272,6 +274,17 @@ void parseArgument(int argc, char** argv){
             g_targetIdentity = argv[i+1];
             g_TxAmount = charToNumber(argv[i+2]);
             i+=3;
+            CHECK_OVER_PARAMETERS
+            break;
+        }
+
+        if(strcmp(argv[i], "-sendtoaddressintick") == 0)
+        {
+            g_cmd = SEND_COIN_IN_TICK;
+            g_targetIdentity = argv[i+1];
+            g_TxAmount = charToNumber(argv[i+2]);
+            g_TxTick = charToNumber(argv[i+3]);
+            i+=4;
             CHECK_OVER_PARAMETERS
             break;
         }

--- a/global.h
+++ b/global.h
@@ -14,6 +14,7 @@ int64_t g_qx_share_transfer_amount = 0;
 
 int64_t g_TxAmount = 0;
 uint16_t g_TxType = 0;
+uint32_t g_TxTick = 0;
 int g_nodePort = DEFAULT_NODE_PORT;
 int g_txExtraDataSize = 0;
 int g_rawPacketSize = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -46,6 +46,13 @@ int run(int argc, char* argv[])
             sanityCheckTxAmount(g_TxAmount);
             makeStandardTransaction(g_nodeIp, g_nodePort, g_seed, g_targetIdentity, g_TxAmount, g_offsetScheduledTick, g_waitUntilFinish);
             break;
+        case SEND_COIN_IN_TICK:
+            sanityCheckNode(g_nodeIp, g_nodePort);
+            sanityCheckSeed(g_seed);
+            sanityCheckIdentity(g_targetIdentity);
+            sanityCheckTxAmount(g_TxAmount);
+            makeStandardTransactionInTick(g_nodeIp, g_nodePort, g_seed, g_targetIdentity, g_TxAmount, g_TxTick, g_waitUntilFinish);
+            break;
         case SEND_CUSTOM_TX:
             sanityCheckNode(g_nodeIp, g_nodePort);
             sanityCheckSeed(g_seed);

--- a/structs.h
+++ b/structs.h
@@ -51,6 +51,7 @@ enum COMMAND
     QX_ORDER=43,
     QX_GET_ORDER=44,
     GET_MINING_SCORE_RANKING=45,
+    SEND_COIN_IN_TICK = 46
 };
 
 struct RequestResponseHeader {

--- a/walletUtils.cpp
+++ b/walletUtils.cpp
@@ -169,8 +169,10 @@ bool verifyTx(Transaction& tx, const uint8_t* extraData, const uint8_t* signatur
     return verify(tx.sourcePublicKey, digest, signature);
 }
 
-void makeStandardTransaction(const char* nodeIp, int nodePort, const char* seed,
-                             const char* targetIdentity, const uint64_t amount, uint32_t scheduledTickOffset,
+
+
+void makeStandardTransactionInTick(const char* nodeIp, int nodePort, const char* seed,
+                             const char* targetIdentity, const uint64_t amount, uint32_t txTick,
                              int waitUntilFinish)
 {
     auto qc = make_qc(nodeIp, nodePort);
@@ -197,7 +199,7 @@ void makeStandardTransaction(const char* nodeIp, int nodePort, const char* seed,
     memcpy(packet.transaction.destinationPublicKey, destPublicKey, 32);
     packet.transaction.amount = amount;
     uint32_t currentTick = getTickNumberFromNode(qc);
-    packet.transaction.tick = currentTick + scheduledTickOffset;
+    packet.transaction.tick = txTick;
     packet.transaction.inputType = 0;
     packet.transaction.inputSize = 0;
     KangarooTwelve((unsigned char*)&packet.transaction,
@@ -227,10 +229,22 @@ void makeStandardTransaction(const char* nodeIp, int nodePort, const char* seed,
         }
         checkTxOnTick(nodeIp, nodePort, txHash, packet.transaction.tick);
     } else {
-        LOG("run ./qubic-cli [...] -checktxontick %u %s\n", currentTick + scheduledTickOffset, txHash);
+        LOG("run ./qubic-cli [...] -checktxontick %u %s\n", txTick, txHash);
         LOG("to check your tx confirmation status\n");
     }
 }
+
+
+void makeStandardTransaction(const char* nodeIp, int nodePort, const char* seed,
+                             const char* targetIdentity, const uint64_t amount, uint32_t scheduledTickOffset,
+                             int waitUntilFinish)
+{
+    auto qc = make_qc(nodeIp, nodePort);
+    uint32_t currentTick = getTickNumberFromNode(qc);
+    uint32_t txTick = currentTick + scheduledTickOffset;
+    makeStandardTransactionInTick(nodeIp, nodePort, seed, targetIdentity, amount, txTick, waitUntilFinish); 
+}
+
 
 void makeCustomTransaction(const char* nodeIp, int nodePort,
                            const char* seed,

--- a/walletUtils.h
+++ b/walletUtils.h
@@ -4,6 +4,11 @@ void printBalance(const char* publicIdentity, const char* nodeIp, int nodePort);
 void makeStandardTransaction(const char* nodeIp, int nodePort, const char* seed,
                              const char* targetIdentity, const uint64_t amount, uint32_t scheduledTickOffset,
                              int waitUntilFinish);
+
+void makeStandardTransactionInTick(const char* nodeIp, int nodePort, const char* seed,
+                             const char* targetIdentity, const uint64_t amount, uint32_t txTick,
+                             int waitUntilFinish);
+
 void makeCustomTransaction(const char* nodeIp, int nodePort,
                            const char* seed,
                            const char* targetIdentity,


### PR DESCRIPTION
## Description

This pull request adds a new functionality to allow adding a transaction into a specific tick. I believe this feature could be beneficial for the project, although I'm not entirely certain if there is already an existing method to achieve this.

## New Command

I have introduced a new command to facilitate this functionality:

```
-sendtoaddressintick <TARGET_IDENTITY> <AMOUNT> <TICK>
```

## Details

The new command enables users to specify the target identity, amount, and the specific tick in which the transaction should be added. This provides more granular control over the transaction process. Probably could be further improved by checking if the specified tick is not in the past.