### PR TITLE
Allow custom signing via the shared lib

### DIFF
--- a/K12AndKeyUtil.h
+++ b/K12AndKeyUtil.h
@@ -2193,7 +2193,7 @@ static bool decode(const uint8_t* Pencoded, point_t P)
     return true;
 }
 
-VOID_FUNC_DECL signCustom(const unsigned char* k, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature)
+VOID_FUNC_DECL signWithNonceK(const unsigned char* k, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature)
 {
     // Requires correctly precalculated k as input!
     // Inputs: 64-byte input (k precomputed), 32-byte publicKey, and messageDigest of size 32 in bytes
@@ -2235,7 +2235,7 @@ VOID_FUNC_DECL sign(const unsigned char* subseed, const unsigned char* publicKey
     // Output: 64-byte signature
     unsigned char k[64];
     KangarooTwelve((unsigned char*)subseed, 32, k, 64);
-    signCustom(k, publicKey, messageDigest, signature);
+    signWithNonceK(k, publicKey, messageDigest, signature);
 }
 
 BOOL_FUNC_DECL verify(const unsigned char* publicKey, const unsigned char* messageDigest, const unsigned char* signature)

--- a/K12AndKeyUtil.h
+++ b/K12AndKeyUtil.h
@@ -2193,16 +2193,14 @@ static bool decode(const uint8_t* Pencoded, point_t P)
     return true;
 }
 
-VOID_FUNC_DECL sign(const unsigned char* subseed, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature)
-{ // SchnorrQ signature generation
-    // It produces the signature signature of a message messageDigest of size 32 in bytes
-    // Inputs: 32-byte subseed, 32-byte publicKey, and messageDigest of size 32 in bytes
+VOID_FUNC_DECL signCustom(const unsigned char* k, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature)
+{
+    // Requires correctly precalculated k as input!
+    // Inputs: 64-byte input (k precomputed), 32-byte publicKey, and messageDigest of size 32 in bytes
     // Output: 64-byte signature
     point_t R;
-    unsigned char k[64] , h[64]  , temp[32 + 64] ;
-    unsigned long long r[8] ;
-
-    KangarooTwelve((unsigned char*)subseed, 32, k, 64);
+    unsigned char h[64] , temp[32 + 64];
+    unsigned long long r[8];
 
     *((__m256i*)(temp + 32)) = *((__m256i*)(k + 32));
     *((__m256i*)(temp + 64)) = *((__m256i*)messageDigest);
@@ -2227,6 +2225,17 @@ VOID_FUNC_DECL sign(const unsigned char* subseed, const unsigned char* publicKey
     {
         _addcarry_u64(_addcarry_u64(_addcarry_u64(_addcarry_u64(0, ((unsigned long long*)signature)[4], CURVE_ORDER_0, &((unsigned long long*)signature)[4]), ((unsigned long long*)signature)[5], CURVE_ORDER_1, &((unsigned long long*)signature)[5]), ((unsigned long long*)signature)[6], CURVE_ORDER_2, &((unsigned long long*)signature)[6]), ((unsigned long long*)signature)[7], CURVE_ORDER_3, &((unsigned long long*)signature)[7]);
     }
+}
+
+VOID_FUNC_DECL sign(const unsigned char* subseed, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature) 
+{
+    // SchnorrQ signature generation
+    // It produces the signature signature of a message messageDigest of size 32 in bytes
+    // Inputs: 32-byte subseed, 32-byte publicKey, and messageDigest of size 32 in bytes
+    // Output: 64-byte signature
+    unsigned char k[64];
+    KangarooTwelve((unsigned char*)subseed, 32, k, 64);
+    signCustom(k, publicKey, messageDigest, signature);
 }
 
 BOOL_FUNC_DECL verify(const unsigned char* publicKey, const unsigned char* messageDigest, const unsigned char* signature)

--- a/fourq-qubic.h
+++ b/fourq-qubic.h
@@ -14,6 +14,7 @@ extern "C" {
 	void ecc_mul_fixed(unsigned long long* k, point_t Q);
 	void encode(point_t P, unsigned char* Pencoded);
 	void sign(const unsigned char* subSeed, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature);
+	void signCustom(const unsigned char* input, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature);
 	bool verify(const unsigned char* publicKey, const unsigned char* messageDigest, const unsigned char* signature);
 
 }

--- a/fourq-qubic.h
+++ b/fourq-qubic.h
@@ -14,7 +14,7 @@ extern "C" {
 	void ecc_mul_fixed(unsigned long long* k, point_t Q);
 	void encode(point_t P, unsigned char* Pencoded);
 	void sign(const unsigned char* subSeed, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature);
-	void signCustom(const unsigned char* input, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature);
+	void signWithNonceK(const unsigned char* input, const unsigned char* publicKey, const unsigned char* messageDigest, unsigned char* signature);
 	bool verify(const unsigned char* publicKey, const unsigned char* messageDigest, const unsigned char* signature);
 
 }


### PR DESCRIPTION
Adds the possibility to not only sign by sub seed but also with a precomputed digest via the shared library. That would allow applications to pass in the 64 byte digest of the sub seed or pass in a custom 64 byte digest like a digest based on the private key instead of the sub seed.

Only problem that I see is that applications could pass a digest that is not computed correctly and create signatures that leak information. Idk how to avoid that.

I don't like the name of the function `signCustom` -> please suggest a better name.

Feel free to discuss anything.