### PR TITLE
Adds install target for the shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,5 +35,7 @@ SET(HEADER_FILES
 )
 ADD_EXECUTABLE(qubic-cli main.cpp ${FILES} ${HEADER_FILES})
 ADD_LIBRARY(fourq-qubic SHARED fourq-qubic.cpp)
+set_property(TARGET fourq-qubic PROPERTY SOVERSION 1)
 target_compile_options(fourq-qubic PRIVATE -DBUILD_4Q_LIB)
+install(TARGETS fourq-qubic LIBRARY)
 


### PR DESCRIPTION
Add cmake --install target for shared libary:

    mkdir build/
    cd build/
    cmake -DCMAKE_BUILD_TYPE=Release ..
    cmake --build .
    sudo cmake --install .

On my system:

    $ sudo cmake --install .
    -- Install configuration: "Release"
    -- Installing: /usr/local/lib/libfourq-qubic.so.1
    -- Installing: /usr/local/lib/libfourq-qubic.so

Creates:

    lrwxrwxrwx 1 root root     19 Jul  9 15:58 libfourq-qubic.so -> libfourq-qubic.so.1
    -rw-r--r-- 1 root root 115968 Jul  9 15:58 libfourq-qubic.so.1
