### PR TITLE
Add ability to dump QX contract file (contract0001).

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Command:
 	-dumpspectrumfile <SPECTRUM_BINARY_FILE> <OUTPUT_CSV_FILE>
 		Dump spectrum file into csv.
 	-dumpuniversefile <UNIVERSE_BINARY_FILE> <OUTPUT_CSV_FILE>
-		Dump spectrum file into csv.
+		Dump universe file into csv.
+	-dumpcontractfile <CONTRACT_BINARY_FILE> <OUTPUT_CSV_FILE>
+		Dump contract file into csv.
 	-makeipobid <CONTRACT_INDEX> <NUMBER_OF_SHARE> <PRICE_PER_SHARE>
 		Participating IPO (dutch auction). valid private key and node ip/port, CONTRACT_INDEX are required.
 	-getipostatus <CONTRACT_INDEX>

--- a/SCUtils.cpp
+++ b/SCUtils.cpp
@@ -12,9 +12,30 @@ void dumpQxContractToCSV(const char* input, const char* output)
 {
     std::cout << "Dumping QX contract file " << input << std::endl;
 
+    // Check the file size
+    FILE* f;
+    {
+        f = fopen(input, "rb"); // Open the file in binary mode
+        if (f == nullptr)
+        {
+            std::cout << "Can not open file! Exit. " << output << std::endl;
+            return;
+        }
+
+        fseek(f, 0, SEEK_END);
+        unsigned long fileSize = (unsigned long)ftell(f);
+        fclose(f);
+
+        if (fileSize != sizeof(QX))
+        {
+            std::cout << "File size is different from QX state size! " << fileSize << " . Expected " << sizeof(QX) << std::endl;
+            return;
+        }
+    }
+
     std::shared_ptr<QX> qxState = std::make_shared<QX>();
 
-    FILE* f = fopen(input, "rb");
+    f = fopen(input, "rb");
     fread(qxState.get(), 1, sizeof(QX), f);
     fclose(f);
 
@@ -78,20 +99,23 @@ void dumpQxContractToCSV(const char* input, const char* output)
     std::cout << "File is written into " << output << std::endl;
 }
 
-void dumpContractToCSV(const char* input, const char* output)
+void dumpQtryContractToCSV(const char* input, const char* output)
+{
+    std::cout << "Dumping Qtry contract file " << input << std::endl;
+}
+
+void dumpContractToCSV(const char* input, uint32_t contractId, const char* output)
 {
     // Checking the contract type
     std::string fileName = input;
     auto extensionLocation = fileName.rfind('.');
-    int contractType = std::stoi(fileName.substr(fileName.rfind('.') - 4, 4));
-
-    switch (contractType)
+    switch (contractId)
     {
     case SCType::SC_TYPE_QX :
         dumpQxContractToCSV(input, output);
         break;
     default:
-        std::cout << "Unsupported contract type: " << contractType << std::endl;
+        std::cout << "Unsupported contract id: " << contractId << std::endl;
         break;
     }
 

--- a/SCUtils.cpp
+++ b/SCUtils.cpp
@@ -1,6 +1,98 @@
 #include <cstring>
 #include "SCUtils.h"
+#include "keyUtils.h"
 #include "structs.h"
+#include "qxStruct.h"
 #include "connection.h"
 #include "logger.h"
 
+#include <iostream>
+
+void dumpQxContractToCSV(const char* input, const char* output)
+{
+    std::cout << "Dumping QX contract file " << input << std::endl;
+
+    std::shared_ptr<QX> qxState = std::make_shared<QX>();
+
+    FILE* f = fopen(input, "rb");
+    fread(qxState.get(), 1, sizeof(QX), f);
+    fclose(f);
+
+    f = fopen(output, "w");
+    {
+       std::string header ="EarnedAmount,DistributedAmount,BurnedAmount,AssetIssuanceFee,TransferFee,TradeFee,Entity,Issuer,AssetName,NumberOfShares,Price\n";
+       fwrite(header.c_str(), 1, header.size(), f);
+    }
+    std::string stringLine = std::to_string(qxState->_earnedAmount)
+                             + "," + std::to_string(qxState->_distributedAmount)
+                             + "," + std::to_string(qxState->_burnedAmount)
+                             + "," + std::to_string(qxState->_assetIssuanceFee)
+                             + "," + std::to_string(qxState->_transferFee)
+                             + "," + std::to_string(qxState->_tradeFee);
+
+    int64_t elementIdx = 0;
+    uint8_t povID[32];
+    char buffer[128];
+    char assetNameBuffer[8];
+    for (int64_t elementIdx = 0; elementIdx < qxState->_entityOrders.population(); elementIdx++)
+    {
+        if (elementIdx > 0)
+        {
+            stringLine = ",,,,,";
+        }
+        // Write data
+        // Entity
+        qxState->_entityOrders.pov(elementIdx, povID);
+
+        memset(buffer, 0, 128);
+        getIdentityFromPublicKey(povID, buffer, false);
+        stringLine = stringLine + "," + buffer;
+
+        // Extract data
+        auto entityOrder = qxState->_entityOrders.element(elementIdx);
+
+        // Issuer
+        memset(buffer, 0, 128);
+        getIdentityFromPublicKey(entityOrder.issuer, buffer, false);
+        stringLine = stringLine + "," + buffer;
+
+        // Asset name
+        memcpy(assetNameBuffer, (char*)&entityOrder.assetName, 8);
+        std::string assetName = assetNameBuffer;
+        stringLine = stringLine + "," + assetName;
+
+        // Number of share
+        stringLine = stringLine + "," + std::to_string(entityOrder.numberOfShares);
+
+        // Price
+        int64_t price = qxState->_entityOrders.priority(elementIdx);
+        stringLine = stringLine + "," + std::to_string(price);
+
+        stringLine += "\n";
+
+        fwrite(stringLine.c_str(), 1, stringLine.size(), f);
+    }
+
+    fclose(f);
+
+    std::cout << "File is written into " << output << std::endl;
+}
+
+void dumpContractToCSV(const char* input, const char* output)
+{
+    // Checking the contract type
+    std::string fileName = input;
+    auto extensionLocation = fileName.rfind('.');
+    int contractType = std::stoi(fileName.substr(fileName.rfind('.') - 4, 4));
+
+    switch (contractType)
+    {
+    case SCType::SC_TYPE_QX :
+        dumpQxContractToCSV(input, output);
+        break;
+    default:
+        std::cout << "Unsupported contract type: " << contractType << std::endl;
+        break;
+    }
+
+}

--- a/SCUtils.h
+++ b/SCUtils.h
@@ -2,4 +2,4 @@
 
 #include <cstdint>
 
-void dumpContractToCSV(const char* input, const char* output);
+void dumpContractToCSV(const char* input, uint32_t contractId, const char* output);

--- a/SCUtils.h
+++ b/SCUtils.h
@@ -1,2 +1,5 @@
+#pragma once
+
 #include <cstdint>
 
+void dumpContractToCSV(const char* input, const char* output);

--- a/argparser.h
+++ b/argparser.h
@@ -65,8 +65,8 @@ void print_help(){
     printf("\t\tDump spectrum file into csv.\n");
     printf("\t-dumpuniversefile <UNIVERSE_BINARY_FILE> <OUTPUT_CSV_FILE>\n");
     printf("\t\tDump universe file into csv.\n");
-    printf("\t-dumpcontractfile <CONTRACT_BINARY_FILE> <OUTPUT_CSV_FILE>\n");
-    printf("\t\tDump contract file into csv.\n");
+    printf("\t-dumpcontractfile <CONTRACT_BINARY_FILE> <CONTRACT_ID> <OUTPUT_CSV_FILE>\n");
+    printf("\t\tDump contract file into csv. Current supported CONTRACT_IDs: 1-QX \n");
     printf("\t-makeipobid <CONTRACT_INDEX> <NUMBER_OF_SHARE> <PRICE_PER_SHARE>\n");
     printf("\t\tParticipating IPO (dutch auction). valid private key and node ip/port, CONTRACT_INDEX are required.\n");
     printf("\t-getipostatus <CONTRACT_INDEX>\n");
@@ -450,8 +450,9 @@ void parseArgument(int argc, char** argv){
         {
             g_cmd = DUMP_CONTRACT_FILE;
             g_dump_binary_file_input = argv[i+1];
-            g_dump_binary_file_output = argv[i+2];
-            i+=3;
+            g_dump_binary_contract_id = charToNumber(argv[i+2]);
+            g_dump_binary_file_output = argv[i+3];
+            i+=4;
             CHECK_OVER_PARAMETERS
             break;
         }

--- a/argparser.h
+++ b/argparser.h
@@ -64,7 +64,9 @@ void print_help(){
     printf("\t-dumpspectrumfile <SPECTRUM_BINARY_FILE> <OUTPUT_CSV_FILE>\n");
     printf("\t\tDump spectrum file into csv.\n");
     printf("\t-dumpuniversefile <UNIVERSE_BINARY_FILE> <OUTPUT_CSV_FILE>\n");
-    printf("\t\tDump spectrum file into csv.\n");
+    printf("\t\tDump universe file into csv.\n");
+    printf("\t-dumpcontractfile <CONTRACT_BINARY_FILE> <OUTPUT_CSV_FILE>\n");
+    printf("\t\tDump contract file into csv.\n");
     printf("\t-makeipobid <CONTRACT_INDEX> <NUMBER_OF_SHARE> <PRICE_PER_SHARE>\n");
     printf("\t\tParticipating IPO (dutch auction). valid private key and node ip/port, CONTRACT_INDEX are required.\n");
     printf("\t-getipostatus <CONTRACT_INDEX>\n");
@@ -444,6 +446,16 @@ void parseArgument(int argc, char** argv){
             break;
         }
 
+        if(strcmp(argv[i], "-dumpcontractfile") == 0)
+        {
+            g_cmd = DUMP_CONTRACT_FILE;
+            g_dump_binary_file_input = argv[i+1];
+            g_dump_binary_file_output = argv[i+2];
+            i+=3;
+            CHECK_OVER_PARAMETERS
+            break;
+        }
+
         if(strcmp(argv[i], "-makeipobid") == 0)
         {
             g_cmd = MAKE_IPO_BID;
@@ -778,7 +790,7 @@ void parseArgument(int argc, char** argv){
             CHECK_OVER_PARAMETERS
             break;
         }
-        
+
         if (strcmp(argv[i], "-gqmpropgetvote") == 0)
         {
             g_cmd = GQMPROP_GET_VOTE;

--- a/global.h
+++ b/global.h
@@ -55,6 +55,7 @@ char* g_qx_asset_transfer_issuer_in_hex;
 
 char* g_dump_binary_file_input;
 char* g_dump_binary_file_output;
+uint32_t g_dump_binary_contract_id = 0;
 
 //IPO bid
 uint32_t g_ipo_contract_index = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -187,6 +187,11 @@ int run(int argc, char* argv[])
             sanityCheckValidString(g_dump_binary_file_output);
             dumpUniverseToCSV(g_dump_binary_file_input, g_dump_binary_file_output);
             break;
+        case DUMP_CONTRACT_FILE:
+            sanityFileExist(g_dump_binary_file_input);
+            sanityCheckValidString(g_dump_binary_file_output);
+            dumpContractToCSV(g_dump_binary_file_input, g_dump_binary_file_output);
+            break;
         case PRINT_QX_FEE:
             sanityCheckNode(g_nodeIp, g_nodePort);
             printQxFee(g_nodeIp, g_nodePort);
@@ -308,7 +313,7 @@ int run(int argc, char* argv[])
             sanityCheckNode(g_nodeIp, g_nodePort);
             sanityCheckSeed(g_seed);
             gqmpropVote(g_nodeIp, g_nodePort, g_seed, g_proposalString, g_voteValueString, g_offsetScheduledTick, g_force);
-            break;            
+            break;
         case GQMPROP_GET_VOTE:
             sanityCheckNode(g_nodeIp, g_nodePort);
             if (g_requestedIdentity)

--- a/main.cpp
+++ b/main.cpp
@@ -190,7 +190,7 @@ int run(int argc, char* argv[])
         case DUMP_CONTRACT_FILE:
             sanityFileExist(g_dump_binary_file_input);
             sanityCheckValidString(g_dump_binary_file_output);
-            dumpContractToCSV(g_dump_binary_file_input, g_dump_binary_file_output);
+            dumpContractToCSV(g_dump_binary_file_input, g_dump_binary_contract_id, g_dump_binary_file_output);
             break;
         case PRINT_QX_FEE:
             sanityCheckNode(g_nodeIp, g_nodePort);

--- a/qxStruct.h
+++ b/qxStruct.h
@@ -190,3 +190,75 @@ static_assert(sizeof(qxOrderAction_input) == sizeof(RemoveFromBidOrder_input), "
 static_assert(sizeof(qxOrderAction_input) == sizeof(RemoveFromAskOrder_input), "wrong implementation");
 static_assert(sizeof(qxOrderAction_input) == sizeof(AddToBidOrder_input), "wrong implementation");
 static_assert(sizeof(qxOrderAction_input) == sizeof(AddToAskOrder_input), "wrong implementation");
+
+struct QX : ContractBase
+{
+    uint64_t _earnedAmount;
+    uint64_t _distributedAmount;
+    uint64_t _burnedAmount;
+
+    uint32_t _assetIssuanceFee; // Amount of qus
+    uint32_t _transferFee; // Amount of qus
+    uint32_t _tradeFee; // Number of billionths
+
+    struct _AssetOrder
+    {
+        uint8_t entity[32];
+        int64_t numberOfShares;
+    };
+    collection<_AssetOrder, 2097152 * X_MULTIPLIER> _assetOrders;
+    static_assert(sizeof(_assetOrders) == 302514192, "The size of the _assetOrders must be the same with core.");
+
+    struct _EntityOrder
+    {
+        uint8_t issuer[32];
+        uint64_t assetName;
+        int64_t numberOfShares;
+    };
+    collection<_EntityOrder, 2097152 * X_MULTIPLIER> _entityOrders;
+    static_assert(sizeof(_entityOrders) == 319291408, "The size of the _entityOrders must be the same with core.");
+
+    // Belows are used for replicate exactly QX struct in core.
+    // TODO: change to "locals" variables and remove from state? -> every func/proc can define struct of "locals" that is passed as an argument (stored on stack structure per processor)
+    int64_t _elementIndex, _elementIndex2;
+    uint8_t _issuerAndAssetName[32];
+    _AssetOrder _assetOrder;
+    _EntityOrder _entityOrder;
+    int64_t _price;
+    int64_t _fee;
+    AssetAskOrders_output::Order _assetAskOrder;
+    AssetBidOrders_output::Order _assetBidOrder;
+    EntityAskOrders_output::Order _entityAskOrder;
+    EntityBidOrders_output::Order _entityBidOrder;
+
+    struct _TradeMessage
+    {
+        uint32_t _contractIndex;
+        uint32_t _type;
+
+        uint8_t issuer[32];
+        uint64_t assetName;
+        int64_t price;
+        int64_t numberOfShares;
+
+        char _terminator;
+    } _tradeMessage;
+
+    struct _NumberOfReservedShares_input
+    {
+        uint8_t issuer[32];
+        uint64_t assetName;
+    } _numberOfReservedShares_input;
+    struct _NumberOfReservedShares_output
+    {
+        int64_t numberOfShares;
+    } _numberOfReservedShares_output;
+};
+
+// Match size between cli and core struct. may be changed in the future
+static constexpr uint64_t QX_STATE_SIZE = 621806120ULL;
+static_assert(sizeof(QX) == QX_STATE_SIZE, "Size of QX must match with core's QX");
+
+//ContractDescription qxContractDescriptions = {"QX", 66, 10000, sizeof(QX)};
+
+

--- a/structs.h
+++ b/structs.h
@@ -67,6 +67,7 @@ enum COMMAND
     CCF_GET_VOTE = 59,
     CCF_GET_VOTING_RESULTS = 60,
     CCF_GET_LATEST_TRANSFERS = 61,
+    DUMP_CONTRACT_FILE = 62,
     TOTAL_COMMAND, // DO NOT CHANGE THIS
 };
 
@@ -561,3 +562,108 @@ struct RespondTxStatus
     }
 };
 #pragma pack(pop)
+
+
+enum SCType
+{
+    SC_TYPE_Contract0State = 0,
+    SC_TYPE_QX = 1,
+    SC_TYPE_QTRY = 2,
+    SC_TYPE_RANDOM = 3,
+    SC_TYPE_QUTIL = 4,
+    SC_TYPE_MLM = 5,
+    SC_TYPE_GQMPROP = 6,
+    SC_TYPE_SWATCH = 7,
+    SC_TYPE_CCF = 8,
+    SC_TYPE_MAX
+};
+
+// Generate contract related structs
+constexpr uint64_t X_MULTIPLIER = 1ULL;
+struct ContractDescription
+{
+    char assetName[8];
+    // constructionEpoch needs to be set to after IPO (IPO is before construction)
+    uint16_t constructionEpoch, destructionEpoch;
+    uint64_t stateSize;
+};
+
+struct ContractBase
+{
+};
+
+template <typename T, uint64_t L>
+struct array
+{
+    static_assert(L && !(L & (L - 1)),
+        "The capacity of the array must be 2^N."
+        );
+    T _values[L];
+};
+
+static const int64_t COLLECTION_NULL_INDEX = -1LL;
+
+// Simplified collection from core
+template <typename T, uint64_t L>
+struct collection
+{
+public:
+
+    // Return maximum number of elements that may be stored.
+    static constexpr uint64_t capacity() { return L; }
+
+    // Return total populations.
+    uint64_t population() { return _population; }
+
+    // Return element value at elementIndex.
+    inline T element(int64_t elementIndex) const { return _elements[elementIndex & (L - 1)].value; }
+
+    // Return overall number of elements.
+    inline uint64_t population() const { return _population; }
+
+    // Return point of view elementIndex belongs to (or 0 id if unused).
+    void pov(int64_t elementIndex, uint8_t* povID) const
+    {
+        memcpy(povID, _povs[_elements[elementIndex & (L - 1)].povIndex].value, 32);
+    }
+
+    // Return priority of elementIndex (or 0 id if unused).
+    int64_t priority(int64_t elementIndex) const
+    {
+        return _elements[elementIndex & (L - 1)].priority;
+    }
+
+private:
+    static_assert(L && !(L & (L - 1)), "The capacity of the collection must be 2^N.");
+    static constexpr int64_t _nEncodedFlags = L > 32 ? 32 : L;
+
+    // Hash map of point of views = element filters, each with one priority queue (or empty)
+    struct PoV
+    {
+        uint8_t value[32];
+        uint64_t population;
+        int64_t headIndex, tailIndex;
+        int64_t bstRootIndex;
+    } _povs[L];
+
+    // 2 bits per element of _povs: 0b00 = not occupied; 0b01 = occupied; 0b10 = occupied but marked
+    // for removal; 0b11 is unused The state "occupied but marked for removal" is needed for finding
+    // the index of a pov in the hash map. Setting an entry to "not occupied" in remove() would
+    // potentially undo a collision, create a gap, and mess up the entry search.
+    uint64_t _povOccupationFlags[(L * 2 + 63) / 64];
+
+    // Array of elements (filled sequentially), each belongs to one PoV / priority queue (or is
+    // empty) Elements of a POV entry will be stored as a binary search tree (BST); so this
+    // structure has some properties related to BST (bstParentIndex, bstLeftIndex, bstRightIndex).
+    struct Element
+    {
+        T value;
+        int64_t priority;
+        int64_t povIndex;
+        int64_t bstParentIndex;
+        int64_t bstLeftIndex;
+        int64_t bstRightIndex;
+    } _elements[L];
+    uint64_t _population;
+    uint64_t _markRemovalCounter;
+};


### PR DESCRIPTION
Currently support Qx first, other contract will support later.
To run use below command

**Old command:**
``` bash 
./qubic-cli -dumpcontractfile <contract file > <ouput csv file>

```
Example:
```
./qubic-cli -dumpcontractfile contract0001.128 qx.csv
```

**UPDATED command:**

``` bash 
./qubic-cli -dumpcontractfile <contract file > <contract id> <ouput csv file>

```
Example:
```
./qubic-cli -dumpcontractfile contract0001.128 1 qx.csv
```

![image](https://github.com/user-attachments/assets/e94f579f-b85d-46a1-80e7-f1331b474104)

