### PR TITLE
Allow run compress before upload and decompress after download file.

### DIFF
--- a/argparser.h
+++ b/argparser.h
@@ -66,9 +66,9 @@ void print_help()
     printf("\t-gettxinfo <TX_ID>\n");
     printf("\t\tGet tx infomation, will print empty if there is no tx or invalid tx. valid node ip/port are required.\n");
     printf("\t-uploadfile <FILE_PATH> [COMPRESS_TOOL]\n");
-    printf("\t\tUpload a file to qubic network. valid node ip/port and seed are required. optional DECOMPRESS_TOOL is use for decompress the file (support: zip(Unix), tar(Win, Unix)) \n");
+    printf("\t\tUpload a file to qubic network. valid node ip/port and seed are required. optional COMPRESS_TOOL is used to compress the file (support: zip(Unix), tar(Win, Unix)) \n");
     printf("\t-downloadfile <TX_ID> <FILE_PATH> [DECOMPRESS_TOOL]\n");
-    printf("\t\tDownload a file to qubic network. valid node ip/port are required. optional DECOMPRESS_TOOL is use for decompress the file (support: zip(Unix), tar(Win, Unix)) \n");
+    printf("\t\tDownload a file to qubic network. valid node ip/port are required. optional DECOMPRESS_TOOL is used to decompress the file (support: zip(Unix), tar(Win, Unix)) \n");
     printf("\t-checktxontick <TICK_NUMBER> <TX_ID>\n");
     printf("\t\tCheck if a transaction is included in a tick. valid node ip/port are required.\n");
     printf("\t-checktxonfile <TX_ID> <TICK_DATA_FILE>\n");

--- a/argparser.h
+++ b/argparser.h
@@ -65,10 +65,10 @@ void print_help()
     printf("\t\tPrint a list of node ip from a seed node ip. Valid node ip/port are required.\n");
     printf("\t-gettxinfo <TX_ID>\n");
     printf("\t\tGet tx infomation, will print empty if there is no tx or invalid tx. valid node ip/port are required.\n");
-    printf("\t-uploadfile <FILE_PATH>\n");
-    printf("\t\tUpload a file to qubic network. valid node ip/port and seed are required.\n");
-    printf("\t-downloadfile <TX_ID> <FILE_PATH>\n");
-    printf("\t\tDownload a file to qubic network. valid node ip/port are required.\n");
+    printf("\t-uploadfile <FILE_PATH> [COMPRESS_TOOL]\n");
+    printf("\t\tUpload a file to qubic network. valid node ip/port and seed are required. optional DECOMPRESS_TOOL is use for decompress the file (support: zip(Unix), tar(Win, Unix)) \n");
+    printf("\t-downloadfile <TX_ID> <FILE_PATH> [DECOMPRESS_TOOL]\n");
+    printf("\t\tDownload a file to qubic network. valid node ip/port are required. optional DECOMPRESS_TOOL is use for decompress the file (support: zip(Unix), tar(Win, Unix)) \n");
     printf("\t-checktxontick <TICK_NUMBER> <TX_ID>\n");
     printf("\t\tCheck if a transaction is included in a tick. valid node ip/port are required.\n");
     printf("\t-checktxonfile <TX_ID> <TICK_DATA_FILE>\n");
@@ -475,6 +475,11 @@ void parseArgument(int argc, char** argv)
             g_cmd = UPLOAD_FILE;
             g_file_path = argv[i+1];
             i+=2;
+            if (i < argc)
+            {
+                g_compress_tool = argv[i];
+                i++;
+            }
             CHECK_OVER_PARAMETERS
             break;
         }
@@ -485,6 +490,11 @@ void parseArgument(int argc, char** argv)
             g_requestedTxId = argv[i+1];
             g_file_path = argv[i+2];
             i+=3;
+            if (i < argc)
+            {
+                g_compress_tool = argv[i];
+                i++;
+            }
             CHECK_OVER_PARAMETERS
             break;
         }

--- a/fileUpload.cpp
+++ b/fileUpload.cpp
@@ -156,13 +156,83 @@ bool uploadFragment(QCPtr& qc, const char* seed, const uint64_t fragmentId,
     }
 }
 
-void uploadFile(const char* nodeIp, const int nodePort, const char* filePath, const char* seed, const uint32_t scheduledTickOffset)
+std::string compressFileWithTool(const char* inputFile, const char* tool)
 {
+    // Cut off the extension if there is any
+    std::string filePathStr = inputFile;
+    std::string compressFileName;
+    size_t lastDot = filePathStr.find_last_of('.');
+    if (lastDot != std::string::npos)
+    {
+        compressFileName = filePathStr.substr(0, lastDot);
+    }
+
+    // Add extension depend on the commmand
+    std::string commandWithArgument;
+    std::string commandStr = tool;
+    if (commandStr.find_last_of("zip") != std::string::npos)
+    {
+        compressFileName = compressFileName + ".zip";
+        commandWithArgument = "zip -9 " + compressFileName + " " + filePathStr;
+    }
+    else if (commandStr.find_last_of("tar") != std::string::npos)
+    {
+        compressFileName = compressFileName + ".tar.gz";
+        commandWithArgument = "tar -czvf " + compressFileName + " " + filePathStr;
+    }
+
+    LOG("Execute command: %s.\n", commandWithArgument.c_str());
+    int sts = system(commandWithArgument.c_str());
+    if (sts != 0)
+    {
+        LOG("Execute command FAILED: %.\n");
+        return "";
+    }
+    return compressFileName;
+}
+
+int decompressFileWithTool(const char* inputFile, const char* tool)
+{
+    // Cut off the extension if there is any
+    std::string decompressFileName = inputFile;
+
+    // Add extension based on the command
+    std::string commandWithArgument;
+    std::string commandStr = tool;
+    if (commandStr.find("zip") != std::string::npos)
+    {
+        commandWithArgument = "unzip " + decompressFileName;
+    }
+    else if (commandStr.find("tar") != std::string::npos)
+    {
+        commandWithArgument = "tar -xzvf " + decompressFileName;
+    }
+
+    LOG("Execute command: %s.\n", commandWithArgument.c_str());
+    int sts = system(commandWithArgument.c_str());
+    if (sts != 0)
+    {
+        LOG("Execute command FAILED: %d.\n", sts);
+        return 1;
+    }
+    return 0;
+}
+
+void uploadFile(const char* nodeIp, const int nodePort, const char* filePath, const char* seed, const uint32_t scheduledTickOffset, const char* compressTool)
+{
+    std::string filePathStr = filePath;
+    // Run the compression if there is any provided
+    if (compressTool)
+    {
+        filePathStr = compressFileWithTool(filePath, compressTool);
+    }
+
+    // Start to upload the file
     size_t fileSize = 0;
     std::string extension;
-    std::ifstream in(filePath, std::ifstream::ate | std::ifstream::binary);
+    std::ifstream in(filePathStr, std::ifstream::ate | std::ifstream::binary);
     fileSize = in.tellg();
-    extension = getExtension(filePath);
+    extension = getExtension(filePathStr);
     if (fileSize == 0)
     {
         LOG("File size is 0. Exit.\n");
@@ -179,7 +249,7 @@ void uploadFile(const char* nodeIp, const int nodePort, const char* filePath, co
     auto qc = make_qc(nodeIp, nodePort);
     std::vector<uint8_t> fragmentData;
     fragmentData.resize(fileSize);
-    FILE* f = fopen(filePath, "rb");
+    FILE* f = fopen(filePathStr.c_str(), "rb");
     fread(fragmentData.data(), 1, fileSize, f);
     fclose(f);
 
@@ -242,7 +312,7 @@ void uploadFile(const char* nodeIp, const int nodePort, const char* filePath, co
     }
 }
 
-void downloadFile(const char* nodeIp, const int nodePort, const char* trailer, const char* outFilePath)
+void downloadFile(const char* nodeIp, const int nodePort, const char* trailer, const char* outFilePath, const char* decompressTool)
 {
     std::vector<uint8_t> fileData;
     uint8_t buffer[1024];
@@ -321,4 +391,11 @@ void downloadFile(const char* nodeIp, const int nodePort, const char* trailer, c
     fwrite(fileData.data(), 1, fileData.size(), f);
     fclose(f);
     LOG("Data have been written to %s\n", outPath.c_str());
+
+    // Run the decompression if there is any provided
+    if (decompressTool)
+    {
+        decompressFileWithTool(outPath.c_str(), decompressTool);
+    }
+
 }

--- a/global.h
+++ b/global.h
@@ -30,6 +30,7 @@ char* g_toogle_main_aux_1 = nullptr;
 int g_set_solution_threshold_epoch = -1;
 int g_set_solution_threshold_value = -1;
 char* g_file_path = nullptr;
+char* g_compress_tool = nullptr;
 
 uint32_t g_requestedTickNumber = 0;
 uint32_t g_offsetScheduledTick = DEFAULT_SCHEDULED_TICK_OFFSET;

--- a/main.cpp
+++ b/main.cpp
@@ -206,12 +206,12 @@ int run(int argc, char* argv[])
         case UPLOAD_FILE:
             sanityCheckNode(g_nodeIp, g_nodePort);
             sanityCheckSeed(g_seed);
-            uploadFile(g_nodeIp, g_nodePort, g_file_path, g_seed, g_offsetScheduledTick);
+            uploadFile(g_nodeIp, g_nodePort, g_file_path, g_seed, g_offsetScheduledTick, g_compress_tool);
             break;
         case DOWNLOAD_FILE:
             sanityCheckNode(g_nodeIp, g_nodePort);
             sanityCheckSeed(g_seed);
-            downloadFile(g_nodeIp, g_nodePort, g_requestedTxId, g_file_path);
+            downloadFile(g_nodeIp, g_nodePort, g_requestedTxId, g_file_path, g_compress_tool);
             break;
         case DUMP_SPECTRUM_FILE:
             sanityFileExist(g_dump_binary_file_input);

--- a/nodeUtils.h
+++ b/nodeUtils.h
@@ -8,7 +8,7 @@ void printSystemInfoFromNode(const char* nodeIp, int nodePort);
 CurrentSystemInfo getSystemInfoFromNode(QCPtr qc);
 uint32_t getTickNumberFromNode(QCPtr qc);
 bool checkTxOnTick(const char* nodeIp, const int nodePort, const char* txHash, uint32_t requestedTick);
-void downloadFile(const char* nodeIp, const int nodePort, const char* trailer, const char* outFilePath);
+void downloadFile(const char* nodeIp, const int nodePort, const char* trailer, const char* outFilePath, const char* compressTool = nullptr);
 int _GetInputDataFromTxHash(QCPtr& qc, const char* txHash, uint8_t* outData, int& dataSize);
 int _GetTxInfo(QCPtr& qc, const char* txHash);
 int getTxInfo(const char* nodeIp, const int nodePort, const char* txHash);
@@ -25,7 +25,7 @@ void dumpSpectrumToCSV(const char* input, const char* output);
 void dumpUniverseToCSV(const char* input, const char* output);
 void sendSpecialCommandGetMiningScoreRanking(const char* nodeIp, const int nodePort, const char* seed, int command);
 void getVoteCounterTransaction(const char* nodeIp, const int nodePort, unsigned int requestedTick, const char* compFileName);
-void uploadFile(const char* nodeIp, const int nodePort, const char* filePath, const char* seed, unsigned int tickOffset);
+void uploadFile(const char* nodeIp, const int nodePort, const char* filePath, const char* seed, unsigned int tickOffset, const char* compressTool = nullptr);
 // remote tools:
 void toogleMainAux(const char* nodeIp, const int nodePort, const char* seed,
                    int command, std::string mode0, std::string mode1);


### PR DESCRIPTION
This PR support 2 tools for compress and decompress file before uploading and after downloading file `tar` and `zip`. It internally calls the command to compress the file.

To upload file,
```
# zip
./qubic-cli -nodeip <IP> -nodeport <PORT> -seed <YOUR_SEED> -uploadfile <YOUR_FILE> zip

# tar
./qubic-cli -nodeip <IP> -nodeport <PORT> -seed <YOUR_SEED> -uploadfile <YOUR_FILE> tar
```

To download file,
```
# zip
./qubic-cli -nodeip <IP> -nodeport <PORT>  -downloadfile <TX_HASH> <YOUR_FILE> zip

# tar
./qubic-cli -nodeip <IP> -nodeport <PORT>  -downloadfile <TX_HASH> <YOUR_FILE> tar
```