### PR TITLE
Ignore RequestComputor message if Node has no Index yet

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -92,7 +92,14 @@ QubicConnection::QubicConnection(const char* nodeIp, int nodePort)
     // receive handshake - exchange peer packets
     mHandshakeData.resize(sizeof(ExchangePublicPeers));
     uint8_t* data = mHandshakeData.data();
-    *((ExchangePublicPeers*)data) = receivePacketWithHeaderAs<ExchangePublicPeers>();   
+    *((ExchangePublicPeers*)data) = receivePacketWithHeaderAs<ExchangePublicPeers>();
+    // If node has no ComputorList or a self-generated ComputorList it will requestComputor upon tcp initialization
+    // Ignore this message if it is here
+    try{
+        *((RequestComputors*)data) = receivePacketWithHeaderAs<RequestComputors>();
+    }
+    catch(std::logic_error& e){
+    }
 }
 
 void QubicConnection::getHandshakeData(std::vector<uint8_t>& buffer)

--- a/structs.h
+++ b/structs.h
@@ -473,6 +473,14 @@ typedef struct
     }
 } ExchangePublicPeers;
 
+typedef struct
+{
+    static constexpr unsigned char type()
+    {
+        return REQUEST_COMPUTORS;
+    }
+} RequestComputors;
+
 struct RequestLog // Fetches log
 {
     unsigned long long passcode[4];


### PR DESCRIPTION
Besides the initial `ExchangePublicPeers` message nodes also send a `RequestComputors` message in case that the node has no ComputorList or uses a self-generated ComputorsList. This leads to an error when requesting getSystemInfo or CurrentTick. This commit checks for such a 'additional' message and ignores it upon initialization of the connection.