### PR TITLE
changing time nonce to microseconds

### DIFF
--- a/nodeUtils.cpp
+++ b/nodeUtils.cpp
@@ -1225,6 +1225,7 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         uint64_t curTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
         uint64_t commandByte = (uint64_t)(SPECIAL_COMMAND_QUERY_TIME) << 56;
         queryTimeMsg.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
+        LOG("Current time used for nonce (query time): %lu", curTime);
 
         KangarooTwelve((unsigned char*)&queryTimeMsg.cmd,
                        sizeof(queryTimeMsg.cmd),
@@ -1279,9 +1280,9 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         sendTimeMsg.header.randomizeDejavu();
         sendTimeMsg.header.setType(PROCESS_SPECIAL_COMMAND);
         uint64_t curTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-        uint64_t extraNonce = 1; // important: since above piece of code is executed too fast, everIncreasingNonceAndCommandTypes are likely the same for 2 packages, so we need extra nonce here
         uint64_t commandByte = (uint64_t)(SPECIAL_COMMAND_SEND_TIME) << 56;
-        sendTimeMsg.cmd.everIncreasingNonceAndCommandType = commandByte | (curTime+extraNonce);
+        sendTimeMsg.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
+        LOG("Current time used for nonce (send time): %lu", curTime);
 
         using namespace std::chrono;
         auto now = system_clock::now();

--- a/nodeUtils.cpp
+++ b/nodeUtils.cpp
@@ -985,7 +985,7 @@ void sendSpecialCommand(const char* nodeIp, const int nodePort, const char* seed
     packet.header.setSize(sizeof(packet));
     packet.header.randomizeDejavu();
     packet.header.setType(PROCESS_SPECIAL_COMMAND);
-    uint64_t curTime = time(NULL);
+    uint64_t curTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     uint64_t commandByte = (uint64_t)(command) << 56;
     packet.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
 
@@ -1047,7 +1047,7 @@ void toogleMainAux(const char* nodeIp, const int nodePort, const char* seed,
     packet.header.setSize(sizeof(packet));
     packet.header.randomizeDejavu();
     packet.header.setType(PROCESS_SPECIAL_COMMAND);
-    uint64_t curTime = time(NULL);
+    uint64_t curTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     uint64_t commandByte = (uint64_t)(command) << 56;
     packet.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
     uint8_t flag = 0;
@@ -1112,7 +1112,7 @@ void setSolutionThreshold(const char* nodeIp, const int nodePort, const char* se
     packet.header.setSize(sizeof(packet));
     packet.header.randomizeDejavu();
     packet.header.setType(PROCESS_SPECIAL_COMMAND);
-    uint64_t curTime = time(NULL);
+    uint64_t curTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     uint64_t commandByte = (uint64_t)(command) << 56;
     packet.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
     packet.cmd.epoch = epoch;
@@ -1222,7 +1222,7 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         queryTimeMsg.header.setSize(sizeof(queryTimeMsg));
         queryTimeMsg.header.randomizeDejavu();
         queryTimeMsg.header.setType(PROCESS_SPECIAL_COMMAND);
-        uint64_t curTime = time(NULL);
+        uint64_t curTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
         uint64_t commandByte = (uint64_t)(SPECIAL_COMMAND_QUERY_TIME) << 56;
         queryTimeMsg.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
 
@@ -1278,7 +1278,7 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         sendTimeMsg.header.setSize(sizeof(sendTimeMsg));
         sendTimeMsg.header.randomizeDejavu();
         sendTimeMsg.header.setType(PROCESS_SPECIAL_COMMAND);
-        uint64_t curTime = time(NULL);
+        uint64_t curTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
         uint64_t extraNonce = 1; // important: since above piece of code is executed too fast, everIncreasingNonceAndCommandTypes are likely the same for 2 packages, so we need extra nonce here
         uint64_t commandByte = (uint64_t)(SPECIAL_COMMAND_SEND_TIME) << 56;
         sendTimeMsg.cmd.everIncreasingNonceAndCommandType = commandByte | (curTime+extraNonce);
@@ -1654,7 +1654,7 @@ void sendSpecialCommandGetMiningScoreRanking(const char* nodeIp, const int nodeP
     packet.header.setSize(sizeof(packet));
     packet.header.randomizeDejavu();
     packet.header.setType(PROCESS_SPECIAL_COMMAND);
-    uint64_t curTime = time(NULL);
+    uint64_t curTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     uint64_t commandByte = (uint64_t)(SPECIAL_COMMAND_GET_MINING_SCORE_RANKING) << 56;
     packet.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
     getSubseedFromSeed((uint8_t*)seed, subseed);


### PR DESCRIPTION
Previously, unix time in seconds was used as nonce. This lead to the nonce not being unique if commands were sent too fast.
Hence, this PR changes the time to microseconds. Note that we cannot use nanoseconds because the number would not fit into 7 bytes.