### PR TITLE
improve precision in synctime

### DIFF
--- a/nodeUtils.cpp
+++ b/nodeUtils.cpp
@@ -1235,7 +1235,7 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         uint64_t curTime = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
         uint64_t commandByte = (uint64_t)(SPECIAL_COMMAND_QUERY_TIME) << 56;
         queryTimeMsg.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
-        LOG("Current unix time (in us) used for nonce (query time): %lu\n\n", curTime);
+        LOG("Current unix time (in us) used for nonce (query time): %llu\n\n", curTime);
 
         // we need to measure the time it takes to finalize the packet because these steps are also executed after the sendTime packet is created later
         auto finalizePacketStartTime = steady_clock::now();
@@ -1296,7 +1296,7 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         uint64_t curTime = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
         uint64_t commandByte = (uint64_t)(SPECIAL_COMMAND_SEND_TIME) << 56;
         sendTimeMsg.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
-        LOG("Current unix time (in us) used for nonce (send time): %lu\n\n", curTime);
+        LOG("Current unix time (in us) used for nonce (send time): %llu\n\n", curTime);
 
         auto finalizePacketTime = duration_cast<system_clock::duration>(nanoseconds(finalizePacketTimeNanosec));
         auto halfRoudTripTime = duration_cast<system_clock::duration>(nanoseconds(roundTripTimeNanosec / 2));

--- a/nodeUtils.cpp
+++ b/nodeUtils.cpp
@@ -1215,6 +1215,8 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
     LOG("CAUTION: MAKE SURE THAT YOUR LOCAL CLOCK IS SET CORRECTLY, FOR EXAMPLE USING NTP.\n");
     LOG("---------------------------------------------------------------------------------\n\n");
 
+    auto qc = make_qc(nodeIp, nodePort);
+
     using namespace std::chrono;
     // get time from node and measure round trip time
     unsigned long long roundTripTimeNanosec = 0;
@@ -1245,8 +1247,6 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         sign(subseed, sourcePublicKey, digest, signature);
         memcpy(queryTimeMsg.signature, signature, 64);
 
-        auto qc = make_qc(nodeIp, nodePort);
-
         auto startTime = steady_clock::now();
 
         qc->sendData((uint8_t*)&queryTimeMsg, queryTimeMsg.header.size());
@@ -1271,8 +1271,6 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         }
 
         finalizePacketTimeNanosec = duration<unsigned long long, std::nano>(startTime - finalizePacketStartTime).count();
-        LOG("Packet finalization took %llu ms\n\n", finalizePacketTimeNanosec / 1000000);
-
         roundTripTimeNanosec = duration<unsigned long long, std::nano>(endTime - startTime).count();
         LOG("Clock status before sync:\n");
         LOG("\tNode time (UTC):  "); logTime(response.utcTime); LOG("  -  round trip time %llu ms\n", roundTripTimeNanosec / 1000000);
@@ -1316,8 +1314,6 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         sign(subseed, sourcePublicKey, digest, signature);
         memcpy(sendTimeMsg.signature, signature, 64);
 
-        auto qc = make_qc(nodeIp, nodePort);
-
         auto startTime = steady_clock::now();
         
         qc->sendData((uint8_t*)&sendTimeMsg, sendTimeMsg.header.size());
@@ -1342,8 +1338,6 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         }
 
         finalizePacketTimeNanosec = duration<unsigned long long, std::nano>(startTime - finalizePacketStartTime).count();
-        LOG("Packet finalization took %llu ms\n\n", finalizePacketTimeNanosec / 1000000);
-
         roundTripTimeNanosec = duration<unsigned long long, std::nano>(endTime - startTime).count();
         LOG("Clock status after sync:\n");
         LOG("\tNode time (UTC):  "); logTime(response.utcTime); LOG("  -  round trip time %llu ms\n", roundTripTimeNanosec / 1000000);

--- a/nodeUtils.cpp
+++ b/nodeUtils.cpp
@@ -1271,7 +1271,7 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         }
 
         finalizePacketTimeNanosec = duration<unsigned long long, std::nano>(startTime - finalizePacketStartTime).count();
-        LOG("Packet finalization took %luu ms\n\n", finalizePacketTimeNanosec / 1000000);
+        LOG("Packet finalization took %llu ms\n\n", finalizePacketTimeNanosec / 1000000);
 
         roundTripTimeNanosec = duration<unsigned long long, std::nano>(endTime - startTime).count();
         LOG("Clock status before sync:\n");
@@ -1342,7 +1342,7 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         }
 
         finalizePacketTimeNanosec = duration<unsigned long long, std::nano>(startTime - finalizePacketStartTime).count();
-        LOG("Packet finalization took %luu ms\n\n", finalizePacketTimeNanosec / 1000000);
+        LOG("Packet finalization took %llu ms\n\n", finalizePacketTimeNanosec / 1000000);
 
         roundTripTimeNanosec = duration<unsigned long long, std::nano>(endTime - startTime).count();
         LOG("Clock status after sync:\n");

--- a/nodeUtils.cpp
+++ b/nodeUtils.cpp
@@ -1215,8 +1215,10 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
     LOG("CAUTION: MAKE SURE THAT YOUR LOCAL CLOCK IS SET CORRECTLY, FOR EXAMPLE USING NTP.\n");
     LOG("---------------------------------------------------------------------------------\n\n");
 
+    using namespace std::chrono;
     // get time from node and measure round trip time
     unsigned long long roundTripTimeNanosec = 0;
+    unsigned long long finalizePacketTimeNanosec = 0;
     {
         LOG("Querying node time ...\n\n");
 
@@ -1228,10 +1230,13 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         queryTimeMsg.header.setSize(sizeof(queryTimeMsg));
         queryTimeMsg.header.randomizeDejavu();
         queryTimeMsg.header.setType(PROCESS_SPECIAL_COMMAND);
-        uint64_t curTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        uint64_t curTime = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
         uint64_t commandByte = (uint64_t)(SPECIAL_COMMAND_QUERY_TIME) << 56;
         queryTimeMsg.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
         LOG("Current unix time (in us) used for nonce (query time): %lu\n\n", curTime);
+
+        // we need to measure the time it takes to finalize the packet because these steps are also executed after the sendTime packet is created later
+        auto finalizePacketStartTime = steady_clock::now();
 
         KangarooTwelve((unsigned char*)&queryTimeMsg.cmd,
                        sizeof(queryTimeMsg.cmd),
@@ -1241,7 +1246,9 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         memcpy(queryTimeMsg.signature, signature, 64);
 
         auto qc = make_qc(nodeIp, nodePort);
-        auto startTime = std::chrono::steady_clock::now();
+
+        auto startTime = steady_clock::now();
+
         qc->sendData((uint8_t*)&queryTimeMsg, queryTimeMsg.header.size());
         
         SpecialCommandSendTime response;
@@ -1254,8 +1261,8 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
             memset(&response, 0, sizeof(SpecialCommandSendTime));
         }        
         
-        auto endTime = std::chrono::steady_clock::now();
-        auto nowLocal = std::chrono::system_clock::now();
+        auto endTime = steady_clock::now();
+        auto nowLocal = system_clock::now();
 
         if ((response.everIncreasingNonceAndCommandType & 0xFFFFFFFFFFFFFF) != (queryTimeMsg.cmd.everIncreasingNonceAndCommandType & 0xFFFFFFFFFFFFFF)) 
         {
@@ -1263,7 +1270,10 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
             return;
         }
 
-        roundTripTimeNanosec = std::chrono::duration<unsigned long long, std::nano>(endTime - startTime).count();
+        finalizePacketTimeNanosec = duration<unsigned long long, std::nano>(startTime - finalizePacketStartTime).count();
+        LOG("Packet finalization took %luu ms\n\n", finalizePacketTimeNanosec / 1000000);
+
+        roundTripTimeNanosec = duration<unsigned long long, std::nano>(endTime - startTime).count();
         LOG("Clock status before sync:\n");
         LOG("\tNode time (UTC):  "); logTime(response.utcTime); LOG("  -  round trip time %llu ms\n", roundTripTimeNanosec / 1000000);
         LOG("\tLocal time (UTC): "); logTime(convertTime(nowLocal)); LOG("\n\n");
@@ -1275,7 +1285,7 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         return;
     }
 
-    // set node clock to local UTC time + half round trip time (not very accurate but simple and sufficient for requirements of 5 seconds)
+    // set node clock to local UTC time + finalize packet time + half round trip time (not very accurate but simple and sufficient for requirements of 5 seconds)
     {
         struct {
             RequestResponseHeader header;
@@ -1285,17 +1295,19 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         sendTimeMsg.header.setSize(sizeof(sendTimeMsg));
         sendTimeMsg.header.randomizeDejavu();
         sendTimeMsg.header.setType(PROCESS_SPECIAL_COMMAND);
-        uint64_t curTime = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        uint64_t curTime = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
         uint64_t commandByte = (uint64_t)(SPECIAL_COMMAND_SEND_TIME) << 56;
         sendTimeMsg.cmd.everIncreasingNonceAndCommandType = commandByte | curTime;
         LOG("Current unix time (in us) used for nonce (send time): %lu\n\n", curTime);
 
-        using namespace std::chrono;
-        auto now = system_clock::now();
+        auto finalizePacketTime = duration_cast<system_clock::duration>(nanoseconds(finalizePacketTimeNanosec));
         auto halfRoudTripTime = duration_cast<system_clock::duration>(nanoseconds(roundTripTimeNanosec / 2));
-        UtcTime timeToSet = convertTime(now + halfRoudTripTime);
+        auto now = system_clock::now();
+        UtcTime timeToSet = convertTime(now + finalizePacketTime + halfRoudTripTime);
         sendTimeMsg.cmd.utcTime = timeToSet;
         LOG("Setting node time to "); logTime(timeToSet); LOG(" ...\n\n");
+
+        auto finalizePacketStartTime = steady_clock::now();
 
         KangarooTwelve((unsigned char*)&sendTimeMsg.cmd,
                        sizeof(sendTimeMsg.cmd),
@@ -1305,7 +1317,9 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
         memcpy(sendTimeMsg.signature, signature, 64);
 
         auto qc = make_qc(nodeIp, nodePort);
-        auto startTime = std::chrono::steady_clock::now();
+
+        auto startTime = steady_clock::now();
+        
         qc->sendData((uint8_t*)&sendTimeMsg, sendTimeMsg.header.size());
 
         SpecialCommandSendTime response;
@@ -1318,8 +1332,8 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
             memset(&response, 0, sizeof(SpecialCommandSendTime));
         }
 
-        auto endTime = std::chrono::steady_clock::now();
-        auto nowLocal = std::chrono::system_clock::now();
+        auto endTime = steady_clock::now();
+        auto nowLocal = system_clock::now();
 
         if (response.everIncreasingNonceAndCommandType != sendTimeMsg.cmd.everIncreasingNonceAndCommandType) 
         {
@@ -1327,7 +1341,10 @@ void syncTime(const char* nodeIp, const int nodePort, const char* seed)
             return;
         }
 
-        roundTripTimeNanosec = std::chrono::duration<unsigned long long, std::nano>(endTime - startTime).count();
+        finalizePacketTimeNanosec = duration<unsigned long long, std::nano>(startTime - finalizePacketStartTime).count();
+        LOG("Packet finalization took %luu ms\n\n", finalizePacketTimeNanosec / 1000000);
+
+        roundTripTimeNanosec = duration<unsigned long long, std::nano>(endTime - startTime).count();
         LOG("Clock status after sync:\n");
         LOG("\tNode time (UTC):  "); logTime(response.utcTime); LOG("  -  round trip time %llu ms\n", roundTripTimeNanosec / 1000000);
         LOG("\tLocal time (UTC): "); logTime(convertTime(nowLocal)); LOG("\n\n");


### PR DESCRIPTION
the time it takes to finalize the packet needs to be taken into account separately now that it's considerably larger than the round trip time

tested on testnet

![image](https://github.com/user-attachments/assets/c122b408-e1f2-400a-a02a-dcf087deef00)

closes #65 